### PR TITLE
Config-api-plateform-json-format

### DIFF
--- a/api/config/packages/api_plateform.yaml
+++ b/api/config/packages/api_plateform.yaml
@@ -1,0 +1,5 @@
+api_platform:
+    formats:
+        json: [ 'application/json' ]
+        jsonld: [ 'application/ld+json' ]
+        html: [ 'text/html' ]


### PR DESCRIPTION
Creation of a "api_plateform.yaml" file to configure the format of the API responses in json